### PR TITLE
Setup update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .project
 .pydevproject
 .settings/
+.vscode/
 
 test_data_spatial/
 test_data_BRB/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/home/scotthavens/.local/share/virtualenvs/pysnobal-VuvZlkhk/bin/python"
-}

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,11 @@ test_requirements = [
     # TODO: put package test requirements here
 ]
 
-
 cmdclass = {}
 
 # make sure we're using GCC
-os.environ["CC"] = "gcc"
+if "CC" not in os.environ:
+    os.environ["CC"] = "gcc"
 
 if sys.platform == 'darwin':
     from distutils import sysconfig
@@ -37,24 +37,28 @@ if sys.platform == 'darwin':
     vars['LDSHARED'] = vars['LDSHARED'].replace('-bundle', '-dynamiclib')
 
 # ------------------------------------------------------------------------------
-# Compiling the C code for the Snobal libary
+# Compiling the C code for the Snobal library
 
 loc = 'pysnobal/c_snobal/libsnobal'
 cwd = os.getcwd()
 sources = glob.glob(os.path.join(loc, '*.c'))
 
 loc = 'pysnobal/c_snobal'
+extra_cc_args = ['-fopenmp', '-O3', '-L./pysnobal']
 sources += [os.path.join(loc, val) for val in ["snobal.pyx"]]
 extensions = [
     Extension(
         "pysnobal.c_snobal.snobal",
         sources,
         # libraries=["snobal"],
-        include_dirs=[numpy.get_include(), 'pysnobal/c_snobal',
-                      'pysnobal/c_snobal/h'],
+        include_dirs=[
+            numpy.get_include(),
+            'pysnobal/c_snobal',
+            'pysnobal/c_snobal/h'
+        ],
         # runtime_library_dirs=['{}'.format(os.path.join(cwd,'pysnobal'))],
-        extra_compile_args=['-fopenmp', '-O3', '-L./pysnobal'],
-        extra_link_args=['-fopenmp', '-O3', '-L./pysnobal']
+        extra_compile_args=extra_cc_args,
+        extra_link_args=extra_cc_args,
     )
 ]
 
@@ -63,7 +67,8 @@ cmdclass.update({'build_ext': build_ext})
 setup(
     name='pysnobal',
     version='0.2.0',
-    description="Python wrapper of the Snobal mass and energy balance snow model",
+    description="Python wrapper of the Snobal mass and "
+                "energy balance snow model",
     long_description=readme + '\n\n' + history,
     author="Scott Havens",
     author_email='scott.havens@ars.usda.gov',

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ test_requirements = [
     # TODO: put package test requirements here
 ]
 
-cmdclass = {}
-
 # make sure we're using GCC
 if "CC" not in os.environ:
     os.environ["CC"] = "gcc"
@@ -62,8 +60,6 @@ extensions = [
     )
 ]
 
-cmdclass.update({'build_ext': build_ext})
-
 setup(
     name='pysnobal',
     version='0.2.0',
@@ -89,6 +85,8 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
-    cmdclass=cmdclass,
+    cmdclass={
+        'build_ext': build_ext
+    },
     ext_modules=extensions,
 )


### PR DESCRIPTION
Two small changes:
* Remove `.vscode` folder
* Allow overriding of used compiler. 
  On my local the `gcc` compiler points to the native OS X one that is older and has no OpenMP support. Installing a working one via `brew` will install the binary with `gcc-9` to not disrupt the Apple developer setup.